### PR TITLE
Add theme-depends logo support in navbar

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,9 @@
 # -----------------------------------------------------------------------------
 
 title: moncloud
-logo: logo-light.svg
+logo: "assets/img/logo-dark.svg"
+logo_light: "assets/img/logo-light.svg"
+logo_dark:  "assets/img/logo-dark.svg"
 first_name: moncloud
 #middle_name: favicon.svg
 #last_name: Name

--- a/_includes/header.liquid
+++ b/_includes/header.liquid
@@ -2,25 +2,23 @@
   <!-- Nav Bar -->
   <nav id="navbar" class="navbar navbar-light navbar-expand-sm {% if site.navbar_fixed %}fixed-top{% else %}sticky-top{% endif %}" role="navigation">
     <div class="container">
-      {% if page.permalink != '/' %}
-        <a class="navbar-brand title font-weight-lighter" href="{{ site.baseurl }}/">
-          {% if site.title == 'blank' %}
-            {% if site.first_name %}
-              <span class="font-weight-bold">
-                {{- site.first_name -}}
-              </span>
-            {% endif %}
-            {% if site.middle_name %}
-              {{- site.middle_name -}}
-            {% endif %}
-            {% if site.last_name %}
-              {{- site.last_name -}}
-            {% endif %}
-          {% else %}
-            {{- site.title -}}
-          {% endif %}
-        </a>
-      {% elsif site.enable_navbar_social %}
+      {%- comment -%} Brand (logo with text fallback) {%- endcomment -%}
+      <a class="navbar-brand" rel="author" href="{{ '/' | relative_url }}">
+        {% if site.logo_light and site.logo_dark %}
+          <img src="{{ site.logo_light | relative_url }}"
+               alt="{{ site.title | default: site.name }}"
+               class="site-logo site-logo--light">
+          <img src="{{ site.logo_dark  | relative_url }}"
+               alt="{{ site.title | default: site.name }}"
+               class="site-logo site-logo--dark">
+        {% elsif site.logo %}
+          <img src="{{ site.logo | relative_url }}"
+               alt="{{ site.title | default: site.name }}">
+        {% else %}
+          {{ site.title | default: site.name }}
+        {% endif %}
+      </a>
+      {% if site.enable_navbar_social %}
         <!-- Social Icons -->
         <div class="navbar-brand social">{% include social.liquid %}</div>
       {% endif %}

--- a/_sass/moncloud-logo.scss
+++ b/_sass/moncloud-logo.scss
@@ -1,0 +1,6 @@
+#navbar .navbar-brand img.site-logo { height:32px; width:auto; vertical-align:middle; }
+#navbar .navbar-brand .site-logo { display:none; }
+#navbar .navbar-brand .site-logo--light { display:inline-block; }
+html[data-theme="dark"] #navbar .navbar-brand .site-logo--light { display:none; }
+html[data-theme="dark"] #navbar .navbar-brand .site-logo--dark  { display:inline-block; }
+

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -23,3 +23,4 @@ $max-content-width: {{ site.max_width }};
   "tabler-icons/tabler-icons-filled.scss",
   "tabler-icons/tabler-icons-outline.scss"
 ;
+@import "moncloud-logo"


### PR DESCRIPTION
Добавили рендер лого с поддержкой разных тем в хедер:

• поправили _config.yml — добавили поддержку двух разных лого;
• добавили лого в header.liquid с фоллбеком на текст;
• дописали кастомный scss с описанием стилей;
• импортнули стили в main.scss.